### PR TITLE
fix[gcp_upload]:add timestamp and padding

### DIFF
--- a/gcp_storage.py
+++ b/gcp_storage.py
@@ -65,11 +65,27 @@ class upload_to_gcp_storage:
 
         for i, image in enumerate(images):
             i_data = 255. * image.cpu().numpy()
-            img = Image.fromarray(np.clip(i_data, 0, 255).astype(np.uint8))
-            # add padding to the filename because the images may be result of a single batch and have the same timestamp
-            image_filename = f"{filename}_{i:03}.png"
+            np_image = np.clip(i_data, 0, 255).astype(np.uint8)
+
+            # Detect number of channels to determine format
+            if np_image.shape[2] == 4:
+                # Has alpha → save as PNG
+                img_format = "PNG"
+                ext = ".png"
+                img = Image.fromarray(np_image, mode="RGBA")
+            else:
+                # No alpha → save as JPEG
+                img_format = "JPEG"
+                ext = ".jpg"
+                img = Image.fromarray(np_image, mode="RGB")
+
+            image_filename = f"{filename}_{i:03}{ext}"
             full_path = os.path.join(full_output_folder, image_filename)
-            img.save(full_path, compress_level=self.compress_level)
+
+            if img_format == "JPEG":
+                img.save(full_path, format="JPEG", quality=90)
+            else:
+                img.save(full_path, format="PNG", compress_level=self.compress_level)
 
             results.append({
                 "filename": image_filename,

--- a/gcp_storage.py
+++ b/gcp_storage.py
@@ -53,8 +53,8 @@ class upload_to_gcp_storage:
             uploaded_urls.append(public_url)
 
         return {
-            "ui": {"images": results},
-            "uploaded_urls": uploaded_urls
+            "ui": {"images": results,"uploaded_urls": uploaded_urls},
+            
         }
 
     def save_images(self, images, filename_prefix):

--- a/gcp_storage.py
+++ b/gcp_storage.py
@@ -1,18 +1,16 @@
 from google.cloud import storage
 import folder_paths
 from PIL import Image
-import json
 import os
 import numpy as np
+import time
 
-config_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),'gcp_config.json')
-     
 class upload_to_gcp_storage:
     def __init__(self):
         self.output_dir = folder_paths.get_output_directory()
         self.type = "output"
         self.compress_level = 4
-        
+
     @classmethod
     def INPUT_TYPES(s):
         return {
@@ -22,51 +20,64 @@ class upload_to_gcp_storage:
                 "bucket_name": ("STRING", {"default": "bucket", "multiline": False}),
                 "bucket_folder_prefix": ("STRING", {"multiline": False}),
                 "gcp_service_json": ("STRING", {"default": 'path', "multiline": False}),
-            },
-            "optional": {},
+            }
         }
-    
+
     RETURN_TYPES = ()
     FUNCTION = "upload_to_gcp_storage"
     OUTPUT_NODE = True
     CATEGORY = "image"
 
-    def upload_to_gcp_storage(self,images,file_name,bucket_name,bucket_folder_prefix,gcp_service_json):
-        print(f"Setting [GOOGLE_APPLICATION_CREDENTIALS] to {gcp_service_json}..")
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]= gcp_service_json
+    def upload_to_gcp_storage(self, images, file_name, bucket_name, bucket_folder_prefix, gcp_service_json):
+        print(f"[GCPStorageNode] Using credentials from: {gcp_service_json}")
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = gcp_service_json
 
-        file = f"{file_name}.png"
-        subfolder = os.path.dirname(os.path.normpath(file))
-        full_output_folder = os.path.join(self.output_dir, subfolder)
-        full_file_path = os.path.join(full_output_folder, file)
+        # Use timestamp in filename for uniqueness
+        timestamp = int(time.time())
+        filename_prefix = f"{file_name}_{timestamp}"
 
-        print(f"Saving file '{file_name}' to {full_file_path}..")
-        results = save_images(self, images,file_name)
+        results = self.save_images(images, filename_prefix)
 
         storage_client = storage.Client()
         bucket = storage_client.bucket(bucket_name)
-        blob = bucket.blob(f"{bucket_folder_prefix}/{file}")
-        print(f"Uploading blob to {bucket_name}/{bucket_folder_prefix}/{file}..")
-        blob.upload_from_filename(full_file_path)
+        uploaded_urls = []
 
-        return {"ui": {"images": results}}
+        for image_meta in results:
+            local_path = os.path.join(self.output_dir, image_meta["subfolder"], image_meta["filename"])
+            remote_path = f"{bucket_folder_prefix}/{image_meta['filename']}"
+            print(f"[GCPStorageNode] Uploading {local_path} → gs://{bucket_name}/{remote_path}")
+            blob = bucket.blob(remote_path)
+            blob.upload_from_filename(local_path)
 
-def save_images(self, images, filename_prefix="ComfyUI"):
-    full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(filename_prefix, self.output_dir, images[0].shape[1], images[0].shape[0])
-    results = list()
-    for (batch_number, image) in enumerate(images):
-        i = 255. * image.cpu().numpy()
-        img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
-        metadata = None
-        file = f"{filename}.png"
-        img.save(os.path.join(full_output_folder, file), pnginfo=metadata, compress_level=self.compress_level)
-        results.append({
-            "filename": file,
-            "subfolder": subfolder,
-            "type": self.type
-        })
+            public_url = f"https://storage.googleapis.com/{bucket_name}/{remote_path}"
+            uploaded_urls.append(public_url)
 
-    return results
+        return {
+            "ui": {"images": results},
+            "uploaded_urls": uploaded_urls
+        }
+
+    def save_images(self, images, filename_prefix):
+        full_output_folder, filename, counter, subfolder, _ = folder_paths.get_save_image_path(
+            filename_prefix, self.output_dir, images[0].shape[1], images[0].shape[0])
+        
+        results = []
+
+        for i, image in enumerate(images):
+            i_data = 255. * image.cpu().numpy()
+            img = Image.fromarray(np.clip(i_data, 0, 255).astype(np.uint8))
+            # add padding to the filename because the images may be result of a single batch and have the same timestamp
+            image_filename = f"{filename}_{i:03}.png"
+            full_path = os.path.join(full_output_folder, image_filename)
+            img.save(full_path, compress_level=self.compress_level)
+
+            results.append({
+                "filename": image_filename,
+                "subfolder": subfolder,
+                "type": self.type
+            })
+
+        return results
 
 NODE_CLASS_MAPPINGS = {
     "GCPStorageNode": upload_to_gcp_storage,


### PR DESCRIPTION
This PR fixes #4 by:
- Adding timestamp-based filename prefixing
- Saving all images in the batch with padded index suffixes
- Uploading all images to GCP
- Returning all public URLs in the response

Tested in ComfyUI with batch size 6, works as expected.